### PR TITLE
fix wrong check: bots are allowd to delete text in private chats

### DIFF
--- a/apis/telegram/init.inc.php
+++ b/apis/telegram/init.inc.php
@@ -53,15 +53,6 @@ class API_TELEGRAM
 
     public function delete_message($chat_id, $msg_id)
     {
-        global $config;
-
-        // make sure that we're technically able to delete a message
-        if($chat_id > 0)
-        {
-            error_log($this->classname . ":deleteMessage: can not delete $msg_id @ $chat_id (not a channel)");
-            return;
-        }
-
         // set parameters
         $params = [
             'chat_id'=>$chat_id,

--- a/apis/telegram/init.inc.php
+++ b/apis/telegram/init.inc.php
@@ -54,7 +54,7 @@ class API_TELEGRAM
     public function delete_message($chat_id, $msg_id)
     {
         global $config;
-        
+
         // set parameters
         $params = [
             'chat_id'=>$chat_id,

--- a/apis/telegram/init.inc.php
+++ b/apis/telegram/init.inc.php
@@ -53,6 +53,8 @@ class API_TELEGRAM
 
     public function delete_message($chat_id, $msg_id)
     {
+        global $config;
+        
         // set parameters
         $params = [
             'chat_id'=>$chat_id,


### PR DESCRIPTION
>
> - Bots can delete outgoing messages in private chats, groups, and supergroups.
>

src: https://core.telegram.org/bots/api#available-methods
