### PR TITLE
Small inconvenience fix

### DIFF
--- a/apis/routing/init.inc.php
+++ b/apis/routing/init.inc.php
@@ -137,9 +137,22 @@ class API_ROUTING
         }
     }
 
+		private function to_lower($string)
+		{
+			if(function_exists('mb_strtolower')){
+				return mb_strtolower($string);
+			}else{
+				return strtolower($string);
+			}
+		}
 
     public function register($trigger, $classname, $description = NULL)
     {
+        $this->hooks[$trigger] = $classname;
+				$trigger_lower = $this->to_lower($trigger);
+				if($trigger_lower !== $trigger){
+					$this->hooks[$trigger_lower] = $classname;
+				}
         $this->hooks[$trigger] = $classname;
         debug_log($this->classname . ": registered class $classname on trigger $trigger");
     }
@@ -160,7 +173,15 @@ class API_ROUTING
         }
         else
         {
-            error_log($this->classname . ": could not resolve trigger $trigger");
+						$trigger_lower = $this->to_lower($trigger);
+						if($trigger_lower !== $trigger){
+							$res = $this->resolve($trigger_lower);
+							if(! $res ){
+								error_log($this->classname . ": could not resolve trigger $trigger");
+							}
+							return $res;
+						}
+						error_log($this->classname . ": could not resolve trigger $trigger");
             return false;
         }
     }

--- a/apis/routing/init.inc.php
+++ b/apis/routing/init.inc.php
@@ -58,6 +58,20 @@ class API_ROUTING
             debug_log($this->classname . ": command trigger detected: $trigger");
 
             $classname = $this->resolve($trigger);
+						if ( ! $classname )
+						{
+							$_chr_pos = strpos($trigger, '@');
+							if ( $_chr_pos !== false )
+							{
+								$_sub_trigger = substr($trigger, 0, $_chr_pos);
+								$classname = $this->resolve($_sub_trigger);
+								if($classname)
+								{
+									$trigger = $_sub_trigger;
+								}
+							}
+						}
+
             if ($classname)
             {
                 $access_permitted = false;

--- a/plugins/heralding/init.inc.php
+++ b/plugins/heralding/init.inc.php
@@ -62,8 +62,14 @@ class PLUGIN_HERALDING
 
         if($chatid < 0)
         {
-            // only reply if we're asked directly. Do not reply to channel messages.
-            return;
+						debug_log($this->classname . ": WAS GROUP MESSAGE");
+            
+						if($chatid !== $keymemberChannel)
+						{
+							// only reply if we're asked directly. Do not reply to channel messages.
+							// except keymembers group
+							return;
+						}
         }
 
         if(!$spacestate)

--- a/plugins/heralding/init.inc.php
+++ b/plugins/heralding/init.inc.php
@@ -85,7 +85,7 @@ class PLUGIN_HERALDING
 
         }
 
-        switch($trigger)
+        switch(strtolower($trigger))
         {
             case "startup":
 

--- a/plugins/procedure/init.inc.php
+++ b/plugins/procedure/init.inc.php
@@ -69,7 +69,7 @@ class PLUGIN_PROCEDURE
         }
         $tok_string = ($_use_tok ? " ".$_tok : "");
 
-        switch($trigger)
+        switch(strtolower($trigger))
         {
             case "bootup":
                 break;


### PR DESCRIPTION

- Commands (especially herald and procedure) are case insensitive now
- Heralding possible from Keymember group (e.q /takeover should now be clickable and working in keymember group)
- strip `@` symbol (e.q. when the bot is addressed in the group)